### PR TITLE
Output upcoming version in it's own output as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ that will be `8.2`.
 
 ## Output
 
-The action comes with 3 outputs, most importantly `version` which contains a JSON list with versions to be used in
+The action comes with 4 outputs, most importantly `version` which contains a JSON list with versions to be used in
 follow up steps:
 
 ```json
@@ -26,7 +26,8 @@ follow up steps:
 ```
 
 And the `highest` and `lowest` outputs that provide the highest PHP version (`8.1` in the `version` output example)
-and the lowest PHP version (`7.3` in the `version` output example) from the `version` list.
+and the lowest PHP version (`7.3` in the `version` output example) from the `version` list. The 4rth output is 
+`upcoming` and will be populated with the upcoming but unreleased next minor or major version of PHP.
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ outputs:
     description: 'The lowest version found in range'
   version:
     description: 'The versions found in range'
+  upcoming:
+    description: 'The upcoming version found in range'
 runs:
   using: 'node12'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ let composerJson = JSON.parse(fs.readFileSync('composer.json'));
 let supportedVersionsRange = composerJson['require']['php'].toString().replace('||', 'PIPEPIPEPLACEHOLDER').replace('|', '||').replace('PIPEPIPEPLACEHOLDER', '||');
 
 let versions = [];
+let upcomingVersion = '';
 
 [
     '5.3',
@@ -30,6 +31,7 @@ if (process.env.INPUT_UPCOMINGRELEASES === 'true') {
     ].forEach(function (version) {
         if (semver.satisfies(version + '.0', supportedVersionsRange)) {
             versions.push(version);
+            upcomingVersion = version;
         }
     });
 }
@@ -40,3 +42,4 @@ console.log(`Highest version found: ${versions[versions.length - 1]}`);
 console.log(`::set-output name=version::${JSON.stringify(versions)}`);
 console.log(`::set-output name=lowest::${versions[0]}`);
 console.log(`::set-output name=highest::${versions[versions.length - 1]}`);
+console.log(`::set-output name=upcoming::${upcomingVersion}`);


### PR DESCRIPTION
This is useful for example when you want to test against coming
versions but don't want to let the build fail due to them.