### PR TITLE
fix for version strings with multiple ||

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ const semver = require('semver');
 const fs = require('fs');
 
 let composerJson = JSON.parse(fs.readFileSync('composer.json'));
-let supportedVersionsRange = composerJson['require']['php'].toString().replace('||', 'PIPEPIPEPLACEHOLDER').replace('|', '||').replace('PIPEPIPEPLACEHOLDER', '||');
+let supportedVersionsRange = composerJson['require']['php'].toString().replaceAll('||', 'PIPEPIPEPLACEHOLDER').replaceAll('|', '||').replaceAll('PIPEPIPEPLACEHOLDER', '||');
 
 let versions = [];
 let upcomingVersion = '';


### PR DESCRIPTION
without `replaceAll` it's not possible to use the script with a version string like
`^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0`