### PR TITLE
Fix haya14busa/action-update-semver to v1.2.1

### DIFF
--- a/.github/workflows/craft-release.yaml
+++ b/.github/workflows/craft-release.yaml
@@ -78,7 +78,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Updated related tags
-        uses: haya14busa/action-update-semver@v1
+        uses: haya14busa/action-update-semver@v1.2.1
         with:
           tag: ${{ env.MILESTONE }}
 


### PR DESCRIPTION
Using `v1` and thus the latest tag causes failures when doing releases