### PR TITLE
Add PHP 8.5 to versions, make 8.6 the ucoming release

### DIFF
--- a/main.js
+++ b/main.js
@@ -47,6 +47,7 @@ let nightlyVersion = '';
 
 if (process.env.INPUT_UPCOMINGRELEASES === 'true') {
     [
+        '8.6',
     ].forEach(function (version) {
         if (semver.satisfies(version + '.0', supportedVersionsRange)) {
             versions.push(version);


### PR DESCRIPTION
Maybe use https://php.watch/api and cache results?